### PR TITLE
Fix check if player is raid or party leader when entering instance

### DIFF
--- a/RCLootCouncil/core.lua
+++ b/RCLootCouncil/core.lua
@@ -1293,7 +1293,7 @@ end
 function RCLootCouncil:OnRaidEnter(arg)
 	-- NOTE: We shouldn't need to call GetML() as it's most likely called on "LOOT_METHOD_CHANGED"
 	-- There's no ML, and lootmethod ~= ML, but we are the group leader
-	if not self.masterLooter and UnitIsGroupLeader("player") then
+	if not self.masterLooter and (IsRaidLeader() or IsPartyLeader()) then
 		-- We don't need to ask the player for usage, so change loot method to master, and make the player ML
 		if db.usage.leader then
 			SetLootMethod("master", self.playerName)


### PR DESCRIPTION
First off, sorry for multiple pull requests.

This fixes this LUA error:

```
1x RCLootCouncil-2.0.4\core.lua:1296: attempt to call global 'UnitIsGroupLeader' (a nil value)
(tail call): ?:
<in C code>: ?
<string>:"safecall Dispatcher[1]":9: in function <[string "safecall Dispatcher[1]"]:5>
(tail call): ?:
AceTimer-3.0-1017:307: in function <...s\ElvUI\Libraries\Ace3\AceTimer-3.0\AceTimer-3.0.lua:298>
```

It also restores the functionality where the addon will ask you if you wanna use RcLootCouncil after entering an instance and you currently don't have Master Looter enabled. The reason it wasn't working before is because "UnitIsGroupLeader" was used which wasn't added to the game until 5.0.4 from my research. I changed it to use "IsRaidLeader() or IsPartyLeader()" which should fill the same role and works in 3.3.5.